### PR TITLE
Fix: Multiprocessing unable to stop

### DIFF
--- a/src/ppk2_api/ppk2_api.py
+++ b/src/ppk2_api/ppk2_api.py
@@ -472,7 +472,7 @@ class PPK2_MP(PPK2_API):
 
     def stop_measuring(self):
         PPK2_API.stop_measuring(self)
-        PPK2_API.get_data(self) # flush the serial buffer (to prevent unicode error on next command)
+        self.get_data() # flush the serial buffer (to prevent unicode error on next command)
         self._quit_evt.set()
         if self._fetcher is not None:
             self._fetcher.join() # join() will block if the queue isn't empty


### PR DESCRIPTION
Using the instance of PPK2_API instead of calling the object directly to fix bad stop behavior when using multiprocessing